### PR TITLE
utime module using mphal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ SRC_C += micropython/extmod/moduhashlib.c
 SRC_C += micropython/extmod/modujson.c
 SRC_C += micropython/extmod/modurandom.c
 SRC_C += micropython/extmod/modure.c
+SRC_C += micropython/extmod/utime_mphal.c
 #SRC_C += modules/camera.c
 SRC_C += modules/device.c
 SRC_C += modules/display.c

--- a/driver/bluetooth_low_energy.c
+++ b/driver/bluetooth_low_energy.c
@@ -462,14 +462,12 @@ void SWI2_IRQHandler(void)
         switch (evt_id)
         {
         case NRF_EVT_FLASH_OPERATION_SUCCESS:
-            log("NRF_EVT_FLASH_OPERATION_SUCCESS");
             {
                 // TODO In case we add a filesystem in the future
                 break;
             }
 
         case NRF_EVT_FLASH_OPERATION_ERROR:
-            log("NRF_EVT_FLASH_OPERATION_ERROR");
             {
                 // TODO In case we add a filesystem in the future
                 break;
@@ -506,7 +504,6 @@ void SWI2_IRQHandler(void)
 
         // When connected
         case BLE_GAP_EVT_CONNECTED:
-            log("BLE_GAP_EVT_CONNECTED");
             {
                 // Set the connection service
                 ble_conn_handle = ble_evt->evt.gap_evt.conn_handle;
@@ -525,7 +522,6 @@ void SWI2_IRQHandler(void)
 
         // When disconnected
         case BLE_GAP_EVT_DISCONNECTED:
-            log("BLE_GAP_EVT_DISCONNECTED");
             {
                 // // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
 
@@ -539,7 +535,6 @@ void SWI2_IRQHandler(void)
 
         // On a phy update request, set the phy speed automatically
         case BLE_GAP_EVT_PHY_UPDATE_REQUEST:
-            log("BLE_GAP_EVT_PHY_UPDATE_REQUEST");
             {
                 // // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
 
@@ -553,7 +548,6 @@ void SWI2_IRQHandler(void)
 
         // Handle requests for changing MTU length
         case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST:
-            log("BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST");
             {
                 // // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
 
@@ -574,7 +568,6 @@ void SWI2_IRQHandler(void)
 
         // When data arrives, we can write it to the buffer
         case BLE_GATTS_EVT_WRITE:
-            log("BLE_GATTS_EVT_WRITE");
             {
                 // // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 // For the entire incoming string
@@ -594,7 +587,6 @@ void SWI2_IRQHandler(void)
 
         // Disconnect on GATT Client timeout
         case BLE_GATTC_EVT_TIMEOUT:
-            log("BLE_GATTC_EVT_TIMEOUT");
             {
                 // assert(!"not reached");
                 break;
@@ -602,7 +594,6 @@ void SWI2_IRQHandler(void)
 
         // Disconnect on GATT Server timeout
         case BLE_GATTS_EVT_TIMEOUT:
-            log("BLE_GATTS_EVT_TIMEOUT");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_disconnect(ble_conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION));
@@ -611,7 +602,6 @@ void SWI2_IRQHandler(void)
 
         // Updates system attributes after a new connection event
         case BLE_GATTS_EVT_SYS_ATTR_MISSING:
-            log("BLE_GATTS_EVT_SYS_ATTR_MISSING");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gatts_sys_attr_set(ble_conn_handle, NULL, 0, 0));
@@ -620,7 +610,6 @@ void SWI2_IRQHandler(void)
 
         // We don't support pairing, so reply with that message
         case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
-            log("BLE_GAP_EVT_SEC_PARAMS_REQUEST");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_sec_params_reply(ble_conn_handle, BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP, NULL, NULL));
@@ -628,7 +617,6 @@ void SWI2_IRQHandler(void)
             }
 
         case BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
-            log("BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_data_length_update(ble_conn_handle, NULL, NULL));
@@ -636,7 +624,6 @@ void SWI2_IRQHandler(void)
             }
 
         case BLE_GAP_EVT_SEC_INFO_REQUEST:
-            log("BLE_GAP_EVT_SEC_INFO_REQUEST");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_sec_info_reply(ble_conn_handle, NULL, NULL, NULL));
@@ -644,7 +631,6 @@ void SWI2_IRQHandler(void)
             }
 
         case BLE_GAP_EVT_SEC_REQUEST:
-            log("BLE_GAP_EVT_SEC_REQUEST");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_authenticate(ble_conn_handle, NULL));
@@ -652,7 +638,6 @@ void SWI2_IRQHandler(void)
             }
 
         case BLE_GAP_EVT_AUTH_KEY_REQUEST:
-            log("BLE_GAP_EVT_AUTH_KEY_REQUEST");
             {
                 // assert(ble_evt->evt.gap_evt.conn_handle == ble_conn_handle);
                 app_err(sd_ble_gap_auth_key_reply(ble_conn_handle, BLE_GAP_AUTH_KEY_TYPE_NONE, NULL));

--- a/main.c
+++ b/main.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/stackctrl.h"
 #include "py/builtin.h"
+#include "mphalport.h"
 
 #include "shared/readline/readline.h"
 #include "shared/runtime/pyexec.h"
@@ -239,8 +240,8 @@ static void touch_interrupt_handler(nrfx_gpiote_pin_t pin,
  */
 int main(void)
 {
-    log_clear();
-    log("MicroPython on Monocle - " BUILD_VERSION " (" MICROPY_GIT_HASH ") ");
+    SEGGER_RTT_printf(0, RTT_CTRL_CLEAR "\r");
+    SEGGER_RTT_printf(0, "MicroPython on Monocle - " BUILD_VERSION " (" MICROPY_GIT_HASH ") ");
 
     // Set up the PMIC and go to sleep if on charge
     monocle_critical_startup();
@@ -270,13 +271,6 @@ int main(void)
     {
         static nrfx_rtc_config_t rtc_config = NRFX_RTC_DEFAULT_CONFIG;
         nrfx_rtc_t rtc = NRFX_RTC_INSTANCE(0);
-
-        /** TODO automate the timer reset
-        uint32 event = nrf_rtc_event_address_get(&rtc, NRF_RTC_EVENT_COMPARE_0);
-        uint32 task = nrf_rtc_task_address_get(&rtc, NRF_RTC_TASK_CLEAR);
-        nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0, event, task);
-        nrf_ppi_channel_enable(NRF_PPI_CHANNEL0);
-        **/
 
         app_err(nrfx_rtc_init(&rtc, &rtc_config, mp_hal_rtc_callback));
         nrfx_rtc_enable(&rtc);

--- a/main.c
+++ b/main.c
@@ -266,6 +266,22 @@ int main(void)
         app_err(nrfx_saadc_channel_config(&channel));
     }
 
+    // Setup an RTC counting milliseconds since now
+    {
+        static nrfx_rtc_config_t rtc_config = NRFX_RTC_DEFAULT_CONFIG;
+        nrfx_rtc_t rtc = NRFX_RTC_INSTANCE(0);
+
+        /** TODO automate the timer reset
+        uint32 event = nrf_rtc_event_address_get(&rtc, NRF_RTC_EVENT_COMPARE_0);
+        uint32 task = nrf_rtc_task_address_get(&rtc, NRF_RTC_TASK_CLEAR);
+        nrf_ppi_channel_endpoint_setup(NRF_PPI_CHANNEL0, event, task);
+        nrf_ppi_channel_enable(NRF_PPI_CHANNEL0);
+        **/
+
+        app_err(nrfx_rtc_init(&rtc, &rtc_config, mp_hal_rtc_callback));
+        nrfx_rtc_enable(&rtc);
+    }
+
     // Set up BLE
     ble_init();
 

--- a/main.c
+++ b/main.c
@@ -274,6 +274,7 @@ int main(void)
 
         app_err(nrfx_rtc_init(&rtc, &rtc_config, mp_hal_rtc_callback));
         nrfx_rtc_enable(&rtc);
+        nrfx_rtc_overflow_enable(&rtc, true);
     }
 
     // Set up BLE

--- a/modules/time.c
+++ b/modules/time.c
@@ -27,33 +27,23 @@
 #include "py/qstr.h"
 #include "py/nlr.h"
 #include "py/runtime.h"
-
+#include "shared/timeutils/timeutils.h"
+#include "extmod/utime_mphal.h"
 #include "nrfx_systick.h"
 
-uint64_t time_at_init;
+uint64_t time_seconds;
 uint64_t time_zone_offset;
 
 STATIC mp_obj_t time___init__(void)
 {
+    if (time_seconds == 0)
+    {
+        mp_hal_start_ticker_timer();
+    }
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(time___init___obj, time___init__);
-
-// STATIC mp_obj_t time_epoch(size_t n_args, const mp_obj_t *args)
-// {
-//     if (n_args == 0)
-//         return mp_obj_new_int(time_at_init + timer_get_uptime_ms() / 1000);
-//     if (n_args == 1)
-//         time_at_init = mp_obj_get_int(args[0]) - timer_get_uptime_ms() / 1000;
-//     return mp_const_none;
-// }
-// STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_epoch_obj, 0, 1, time_epoch);
-
-STATIC mp_obj_t time_ticks_ms(void)
-{
-    return 0; // TODO mp_obj_new_int(timer_get_uptime_ms());
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_ticks_ms_obj, time_ticks_ms);
 
 STATIC mp_obj_t time_sleep(mp_obj_t secs_in)
 {
@@ -64,114 +54,77 @@ STATIC mp_obj_t time_sleep(mp_obj_t secs_in)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_obj, time_sleep);
 
-STATIC mp_obj_t time_sleep_ms(mp_obj_t msecs_in)
+STATIC mp_obj_t time_zone(mp_obj_t hours, mp_obj_t minutes)
 {
-    uint64_t msecs = mp_obj_get_int(msecs_in);
-
-    nrfx_systick_delay_ms(msecs);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_ms_obj, time_sleep_ms);
-
-STATIC mp_obj_t time_zone(mp_obj_t hours_in, mp_obj_t minutes_in)
-{
-    int16_t hours = mp_obj_get_int(hours_in);
-    int16_t minutes = mp_obj_get_int(minutes_in);
-
-    time_zone_offset = hours * 3600 + minutes * 60;
+    time_zone_offset = mp_obj_get_int(hours) * 3600;
+    time_zone_offset += mp_obj_get_int(minutes) * 60;
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(time_zone_obj, time_zone);
 
-static inline bool isleap(int year)
-{
-    return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);
-}
-
-static inline int mdays(int mon, int year)
-{
-    return (mon == 2) ? (28 + isleap(year)) : (30 + (mon + (mon > 7)) % 2);
-}
-
 STATIC mp_obj_t time_time(size_t n_args, const mp_obj_t *args)
 {
-    mp_obj_t dict_out = mp_obj_new_dict(0);
-    mp_obj_dict_t *dict = MP_OBJ_TO_PTR(dict_out);
-    time_t t;
-    int tm_sec, tm_min, tm_hour, tm_mday, tm_mon, tm_year, days;
+    mp_int_t seconds;
 
-    // get the time to convert from one way or another
-    if (n_args == 0)
-        t = 0; // TODO t = time_at_init + timer_get_uptime_ms() / 1000;
+    // Get current date and time.
+    if (n_args == 0 || args[0] == mp_const_none)
+    {
+        seconds = time_seconds;
+    }
     else
-        t = mp_obj_get_int(args[0]);
+    {
+        seconds = mp_obj_get_int(args[0]);
+    }
 
-    // apply the time zone offset to get local time
-    t += time_zone_offset;
-
-    // compute time components
-    tm_sec = t % 60;
-    t /= 60;
-    tm_min = t % 60;
-    t /= 60;
-    tm_hour = t % 24;
-    t /= 24;
-
-    // compute date components
-    for (tm_year = 1970; t >= (days = (365 + isleap(tm_year))); tm_year++)
-        t -= days;
-    for (tm_mon = 1; t >= (days = mdays(tm_mon, tm_year)); tm_mon++)
-        t -= days;
-    tm_mday = t + 1;
-
-    // fill the fields of a python dict
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_sec), MP_OBJ_NEW_SMALL_INT(tm_sec));
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_min), MP_OBJ_NEW_SMALL_INT(tm_min));
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_hour), MP_OBJ_NEW_SMALL_INT(tm_hour));
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_mday), MP_OBJ_NEW_SMALL_INT(tm_mday));
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_mon), MP_OBJ_NEW_SMALL_INT(tm_mon));
-    mp_obj_dict_store(dict, MP_ROM_QSTR(MP_QSTR_year), MP_OBJ_NEW_SMALL_INT(tm_year));
-
-    // return the dict
-    return dict_out;
+    // Convert given seconds to tuple.
+    timeutils_struct_time_t tm;
+    timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
+    mp_obj_t tuple[8] = {
+        tuple[0] = mp_obj_new_int(tm.tm_year),
+        tuple[1] = mp_obj_new_int(tm.tm_mon),
+        tuple[2] = mp_obj_new_int(tm.tm_mday),
+        tuple[3] = mp_obj_new_int(tm.tm_hour),
+        tuple[4] = mp_obj_new_int(tm.tm_min),
+        tuple[5] = mp_obj_new_int(tm.tm_sec),
+        tuple[6] = mp_obj_new_int(tm.tm_wday),
+        tuple[7] = mp_obj_new_int(tm.tm_yday),
+    };
+    return mp_obj_new_tuple(8, tuple);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_time_obj, 0, 1, time_time);
 
 STATIC mp_obj_t time_mktime(mp_obj_t dict)
 {
-    int sec = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_sec)));
-    int min = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_min)));
-    int hour = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_hour)));
-    int day = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mday)));
-    int mon = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mon)));
-    int year = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_year)));
-
-    // accumulate seconds from the time
-    sec = sec + min * 60 + hour * 3600;
-
-    // accumulate seconds from the date
-    for (mon--; mon > 0; mon--)
-        day = day + mdays(mon, year);
-    day = day - 1 + year / 400 * 146097 + year % 400 / 100 * 36524 + year % 100 / 4 * 1461 + year % 4 / 1 * 365;
-    sec += (day - 719527) * 86400;
-
-    // the result as an integer
-    return mp_obj_new_int(sec);
+    mp_int_t year = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_year)));
+    mp_int_t mon = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mon)));
+    mp_int_t mday = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mday)));
+    mp_int_t hour = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_hour)));
+    mp_int_t min = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_min)));
+    mp_int_t sec = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_sec)));
+    return mp_obj_new_int(timeutils_mktime(year, mon, mday, hour, min, sec));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_mktime_obj, time_mktime);
 
 STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
-    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_time)},
-    {MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&time___init___obj)},
+    {MP_ROM_QSTR(MP_QSTR___name__),     MP_ROM_QSTR(MP_QSTR_time)},
 
-    // methods
-    // {MP_ROM_QSTR(MP_QSTR_epoch), MP_ROM_PTR(&time_epoch_obj)},
-    {MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&time_ticks_ms_obj)},
-    {MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&time_sleep_obj)},
-    {MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&time_sleep_ms_obj)},
-    {MP_ROM_QSTR(MP_QSTR_mktime), MP_ROM_PTR(&time_mktime_obj)},
-    {MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&time_time_obj)},
-    {MP_ROM_QSTR(MP_QSTR_zone), MP_ROM_PTR(&time_zone_obj)},
+    // custom methods
+    {MP_ROM_QSTR(MP_QSTR_mktime),       MP_ROM_PTR(&time_mktime_obj)},
+    {MP_ROM_QSTR(MP_QSTR_time),         MP_ROM_PTR(&time_time_obj)},
+    {MP_ROM_QSTR(MP_QSTR_zone),         MP_ROM_PTR(&time_zone_obj)},
+    {MP_ROM_QSTR(MP_QSTR_epoch),        MP_ROM_PTR(&time_epoch_obj)},
+    {MP_ROM_QSTR(MP_QSTR_sleep),        MP_ROM_PTR(&time_sleep_obj)},
+
+    // standard methods
+    {MP_ROM_QSTR(MP_QSTR_sleep),        MP_ROM_PTR(&mp_utime_sleep_obj)},
+    {MP_ROM_QSTR(MP_QSTR_sleep_ms),     MP_ROM_PTR(&mp_utime_sleep_ms_obj)},
+    {MP_ROM_QSTR(MP_QSTR_sleep_us),     MP_ROM_PTR(&mp_utime_sleep_us_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ticks_ms),     MP_ROM_PTR(&mp_utime_ticks_ms_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ticks_us),     MP_ROM_PTR(&mp_utime_ticks_us_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ticks_cpu),    MP_ROM_PTR(&mp_utime_ticks_cpu_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ticks_diff),   MP_ROM_PTR(&mp_utime_ticks_diff_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ticks_add),    MP_ROM_PTR(&mp_utime_ticks_add_obj)},
+    {MP_ROM_QSTR(MP_QSTR_time_ns),      MP_ROM_PTR(&mp_utime_time_ns_obj)},
 };
 STATIC MP_DEFINE_CONST_DICT(time_module_globals, time_module_globals_table);
 

--- a/modules/time.c
+++ b/modules/time.c
@@ -38,6 +38,7 @@ STATIC mp_obj_t time_epoch(size_t n_args, const mp_obj_t *args)
 {
     if (n_args == 0)
     {
+        SEGGER_RTT_printf(0, "ticks_ms=%d\r\n", mp_hal_ticks_ms());
         return mp_obj_new_int(time_since_boot + mp_hal_ticks_ms() / 1000);
     }
     else
@@ -125,12 +126,16 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_time_obj, 0, 1, time_time);
 
 STATIC mp_obj_t time_mktime(mp_obj_t dict)
 {
+    if (!mp_obj_is_type(dict, &mp_type_dict))
+    {
+        mp_raise_TypeError(MP_ERROR_TEXT("argument must be a dict"));
+    }
     mp_int_t year = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_year)));
-    mp_int_t mon = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mon)));
+    mp_int_t mon  = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mon)));
     mp_int_t mday = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_mday)));
     mp_int_t hour = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_hour)));
-    mp_int_t min = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_min)));
-    mp_int_t sec = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_sec)));
+    mp_int_t min  = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_min)));
+    mp_int_t sec  = mp_obj_get_int(mp_obj_dict_get(dict, MP_ROM_QSTR(MP_QSTR_sec)));
     return mp_obj_new_int(timeutils_mktime(year, mon, mday, hour, min, sec));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_mktime_obj, time_mktime);

--- a/modules/time.c
+++ b/modules/time.c
@@ -38,7 +38,6 @@ STATIC mp_obj_t time_epoch(size_t n_args, const mp_obj_t *args)
 {
     if (n_args == 0)
     {
-        SEGGER_RTT_printf(0, "ticks_ms=%d\r\n", mp_hal_ticks_ms());
         return mp_obj_new_int(time_since_boot + mp_hal_ticks_ms() / 1000);
     }
     else

--- a/monocle-core/monocle.h
+++ b/monocle-core/monocle.h
@@ -112,17 +112,13 @@ i2c_response_t i2c_write(uint8_t device_address_7bit,
  * @brief Logging and error handling macros.
  */
 
-#define log(format, ...) SEGGER_RTT_printf(0, "\r\n" format, ##__VA_ARGS__)
-
-#define log_clear() SEGGER_RTT_printf(0, RTT_CTRL_CLEAR "\r");
-
 #define app_err(eval)                                                          \
     do                                                                         \
     {                                                                          \
         nrfx_err_t err = (eval);                                               \
         if (0x0000FFFF & err)                                                  \
         {                                                                      \
-            log("App error code: 0x%x at %s:%u\r\n", err, __FILE__, __LINE__); \
+            SEGGER_RTT_printf(0, "App error code: 0x%x at %s:%u\r\n", err, __FILE__, __LINE__); \
             if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)              \
             {                                                                  \
                 __BKPT();                                                      \

--- a/mpconfigport.h
+++ b/mpconfigport.h
@@ -135,6 +135,8 @@
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
+#define MICROPY_EPOCH_IS_1970 (1)
+
 #define MP_SSIZE_MAX (0x7fffffff)
 
 typedef int mp_int_t;

--- a/mpconfigport.h
+++ b/mpconfigport.h
@@ -24,9 +24,8 @@
 
 #pragma once
 
-#include "mphalport.h"
-#include <stdint.h>
 #include <alloca.h>
+#include "mphalport.h"
 
 #define MICROPY_BANNER_MACHINE "Monocle on nRF52832"
 
@@ -108,7 +107,7 @@
 #define MICROPY_PY_BUILTINS_COMPLEX (0)
 #define MICROPY_FLOAT_IMPL (MICROPY_FLOAT_IMPL_FLOAT)
 #define MICROPY_LONGINT_IMPL (MICROPY_LONGINT_IMPL_MPZ)
-// #define MP_NEED_LOG2 (1)
+#define MP_NEED_LOG2 (1)
 
 #define MICROPY_PY_UBINASCII (1)
 #define MICROPY_PY_UBINASCII_CRC32 (1)
@@ -133,15 +132,13 @@
 #define MICROPY_PY_URE_SUB (1)
 #define MICROPY_PY_UHEAPQ (1)
 
+#define MICROPY_PY_UTIME_MP_HAL (1)
+
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MICROPY_EPOCH_IS_1970 (1)
 
 #define MP_SSIZE_MAX (0x7fffffff)
-
-typedef int mp_int_t;
-typedef unsigned int mp_uint_t;
-typedef long mp_off_t;
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/mphalport.c
+++ b/mphalport.c
@@ -28,7 +28,7 @@
 #include "py/runtime.h"
 #include "mpconfigport.h"
 #include "driver/bluetooth_low_energy.h"
-#include "nrfx_rtc.h"
+#include "nrfx_timer.h"
 #include "nrfx_systick.h"
 
 const char help_text[] = {
@@ -45,27 +45,27 @@ const char help_text[] = {
     "help(module_name)\n"};
 
 // this overflows after 49 days without reboot.
-static uint32_t rtc_overflows;
+static volatile uint32_t uptime_ms;
 
-void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type)
+void mp_hal_timer_1ms_callback(nrf_timer_event_t event, void *context)
 {
-    SEGGER_RTT_printf(0, "%s\r\n", __func__);
-    rtc_overflows += (int_type == NRFX_RTC_INT_OVERFLOW);
+    (void)event;
+    uptime_ms++;
 }
 
 mp_uint_t mp_hal_ticks_ms(void)
 {
-    return (uint64_t)(1000 * rtc_overflows / RTC_INPUT_FREQ);
+    return uptime_ms;
 }
 
 mp_uint_t mp_hal_ticks_us(void)
 {
-    return (uint64_t)(1000 * mp_hal_ticks_ms());
+    return uptime_ms * 1000;
 }
 
 mp_uint_t mp_hal_ticks_ns(void)
 {
-    return (uint64_t)(1000 * 1000 * mp_hal_ticks_ms());
+    return uptime_ms * 1000 * 1000;
 }
 
 mp_uint_t mp_hal_ticks_cpu(void)

--- a/mphalport.c
+++ b/mphalport.c
@@ -28,6 +28,7 @@
 #include "py/runtime.h"
 #include "mpconfigport.h"
 #include "driver/bluetooth_low_energy.h"
+#include "nrfx_rtc.h"
 
 const char help_text[] = {
     "Welcome to MicroPython!\n\n"
@@ -112,4 +113,16 @@ void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len)
 int mp_hal_generate_random_seed(void)
 {
     return 0;
+}
+
+static uint32_t uptime_ms;
+
+void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type)
+{
+    uptime_ms += (int_type == NRFX_RTC_INT_COMPARE0);
+}
+
+mp_uint_t mp_hal_ticks_ms(void)
+{
+    return utime_ms;
 }

--- a/mphalport.c
+++ b/mphalport.c
@@ -49,6 +49,7 @@ static uint32_t rtc_overflows;
 
 void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type)
 {
+    SEGGER_RTT_printf(0, "%s\r\n", __func__);
     rtc_overflows += (int_type == NRFX_RTC_INT_OVERFLOW);
 }
 

--- a/mphalport.h
+++ b/mphalport.h
@@ -25,11 +25,7 @@
 #pragma once
 
 #include "mpconfigport.h"
-
-// TODO we can remove this and use the keyboard interrupt functions
-static inline void mp_hal_set_interrupt_char(char c)
-{
-    (void)c;
-}
+#include "nrfx_rtc.h"
 
 int mp_hal_generate_random_seed(void);
+void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type);

--- a/mphalport.h
+++ b/mphalport.h
@@ -24,8 +24,18 @@
 
 #pragma once
 
-#include "mpconfigport.h"
 #include "nrfx_rtc.h"
+#include "mpconfigport.h"
+
+typedef int mp_int_t;
+typedef unsigned int mp_uint_t;
+typedef long mp_off_t;
 
 int mp_hal_generate_random_seed(void);
 void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type);
+void mp_hal_print_strn(void *env, const char *str, size_t len);
+mp_uint_t mp_hal_ticks_ms(void);
+mp_uint_t mp_hal_ticks_us(void);
+void mp_hal_delay_ms(mp_uint_t ms);
+void mp_hal_delay_us(mp_uint_t us);
+void mp_hal_set_interrupt_char(char c);

--- a/mphalport.h
+++ b/mphalport.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "nrfx_rtc.h"
+#include "nrf_timer.h"
 #include "mpconfigport.h"
 
 typedef int mp_int_t;
@@ -32,7 +32,7 @@ typedef unsigned int mp_uint_t;
 typedef long mp_off_t;
 
 int mp_hal_generate_random_seed(void);
-void mp_hal_rtc_callback(nrfx_rtc_int_type_t int_type);
+void mp_hal_timer_1ms_callback(nrf_timer_event_t event, void *context);
 void mp_hal_print_strn(void *env, const char *str, size_t len);
 mp_uint_t mp_hal_ticks_ms(void);
 mp_uint_t mp_hal_ticks_us(void);

--- a/nrfx_config.h
+++ b/nrfx_config.h
@@ -56,6 +56,7 @@
 #define NRFX_TIMER_ENABLED 1
 #define NRFX_TIMER0_ENABLED 1 // Used by the SoftDevice
 #define NRFX_TIMER1_ENABLED 1 // Used for "from machine import Timer"
+#define NRFX_TIMER3_ENABLED 1 // Used for maintaining the time
 #define NRFX_TIMER4_ENABLED 1 // Used for checking battery state
 #define NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY 7
 

--- a/nrfx_config.h
+++ b/nrfx_config.h
@@ -24,6 +24,14 @@
 
 #pragma once
 
+#include "nrf.h"
+
+// For every module, it might be necessary to set the IRQ priority to
+// 7 so that the Nordic Uart Service (NUS) gets a higher priority.
+
+#define NRFX_LOG_ENABLED 1
+#define NRFX_LOG_UART_DISABLED 1
+
 #define NRFX_GPIOTE_ENABLED 1
 #define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
 #define NRFX_GPIOTE_DEFAULT_CONFIG_IRQ_PRIORITY 7

--- a/nrfx_log.h
+++ b/nrfx_log.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include "monocle.h"
+#include "SEGGER_RTT.h"
 
-#define NRFX_LOG_ERROR(format, ...) log(format, ##__VA_ARGS__)
+#define NRFX_LOG_ERROR(format, ...) SEGGER_RTT_printf(0, format, ##__VA_ARGS__)
 #define NRFX_LOG_WARNING(format, ...)
 #define NRFX_LOG_INFO(format, ...)
 #define NRFX_LOG_DEBUG(format, ...)


### PR DESCRIPTION
This uses `micropython/extmod/utime_mphal.c` primitives to pass them over to uasyncio.
The needed functions on mpahaport.c are implemented as needed.