### PR TITLE
device.insomnia()

### DIFF
--- a/modules/device.c
+++ b/modules/device.c
@@ -116,6 +116,13 @@ STATIC mp_obj_t device_reset_cause(void)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(device_reset_cause_obj, device_reset_cause);
 
+STATIC mp_obj_t device_insomnia(mp_obj_t enabled)
+{
+    monocle_insomnia = mp_obj_is_true(enabled);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(device_insomnia_obj, device_insomnia);
+
 STATIC const mp_rom_map_elem_t device_module_globals_table[] = {
 
     {MP_ROM_QSTR(MP_QSTR_NAME), MP_ROM_PTR(&device_name_obj)},
@@ -123,6 +130,7 @@ STATIC const mp_rom_map_elem_t device_module_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_VERSION), MP_ROM_PTR(&device_version_obj)},
     {MP_ROM_QSTR(MP_QSTR_GIT_TAG), MP_ROM_PTR(&device_git_tag_obj)},
     {MP_ROM_QSTR(MP_QSTR_battery_level), MP_ROM_PTR(&device_battery_level_obj)},
+    {MP_ROM_QSTR(MP_QSTR_insomnia), MP_ROM_PTR(&device_insomnia_obj)},
     {MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&device_reset_obj)},
     {MP_ROM_QSTR(MP_QSTR_reset_cause), MP_ROM_PTR(&device_reset_cause_obj)},
 };

--- a/monocle-core/monocle-critical.c
+++ b/monocle-core/monocle-critical.c
@@ -37,6 +37,8 @@ static const nrfx_twim_t i2c_bus_0 = NRFX_TWIM_INSTANCE(0);
 static const nrfx_twim_t i2c_bus_1 = NRFX_TWIM_INSTANCE(1);
 static const nrfx_spim_t spi_bus_2 = NRFX_SPIM_INSTANCE(2);
 
+bool monocle_insomnia = false;
+
 /**
  * @brief Startup and PMIC initialization.
  *
@@ -54,7 +56,7 @@ static void check_if_battery_charging_and_sleep(nrf_timer_event_t event_type,
     i2c_response_t charging_response = i2c_read(PMIC_I2C_ADDRESS, 0x03, 0x0C);
     app_err(charging_response.fail);
 
-    if (charging_response.value)
+    if (!monocle_insomnia && charging_response.value)
     {
         // Turn off Bluetooth
         app_err(sd_softdevice_disable());

--- a/monocle-core/monocle.h
+++ b/monocle-core/monocle.h
@@ -82,6 +82,12 @@ void monocle_enter_bootloader(void);
 extern bool not_real_hardware;
 
 /**
+ * @brief Prevents to go to sleep when the charge starts.
+ */
+
+extern bool monocle_insomnia;
+
+/**
  * @brief I2C addresses.
  */
 


### PR DESCRIPTION
This is only here for preview, not even sure we wish that in.

Just a small edit to the monocle-critical for adding a boolean flag to keep the device on.

That turned to be useful without a battery simulator, and some users were suggesting they would use the Monocle that way.

Let me know if it should be avoided or modified!