### PR TITLE
print a message upon micropython.update()

### DIFF
--- a/modules/update.py
+++ b/modules/update.py
@@ -25,6 +25,9 @@
 import __update
 
 def micropython():
+    print("Monocle will now enter update mode.")
+    print("If the update is not started within 5 minutes, it will return to normal mode.")
+    print("If the update fails, it will stay in the update mode and you can try again.")
     __update.nrf52()
 
 def fpga():


### PR DESCRIPTION
This warns the user that it is normal and expected that a disconnect happens, and points at the next step:
performing the update procedure.