### PR TITLE
Raise the limit to draw elements

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -86,7 +86,7 @@ typedef struct
     arg_t arg;
 } obj_t;
 
-obj_t obj_list[50];
+obj_t obj_list[512];
 size_t obj_num;
 
 static uint8_t const *font = font_50;


### PR DESCRIPTION
We can set an arbitrary limit for it, it does not take-up a lot of memory:

```
typedef struct
{
    int16_t x, y, width, height;
    uint8_t yuv444[3];
    uint8_t type;
    uint32_t arg;
} obj_t;
```

So `(4 + 3 + 1 + 4) * 512` = 6144 bytes only out of 65536 in total.