### PR TITLE
More interrupt handlers for debugging purposes

### DIFF
--- a/monocle-core/monocle-startup.c
+++ b/monocle-core/monocle-startup.c
@@ -37,7 +37,22 @@ extern void SystemInit(void);
 
 void Default_Handler(void)
 {
-    app_err(0xDEADBEEF);
+    app_err(0xDEAD0000);
+}
+
+void HardFault_Handler(void)
+{
+    app_err(0xDEAD0001);
+}
+
+void BusFault_Handler(void)
+{
+    app_err(0xDEAD0002);
+}
+
+void UsageFault_Handler(void)
+{
+    app_err(0xDEAD0003);
 }
 
 void Reset_Handler(void)
@@ -69,10 +84,7 @@ void Reset_Handler(void)
  */
 
 void NMI_Handler(void) __attribute__((weak, alias("Default_Handler")));
-void HardFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
 void MemoryManagement_Handler(void) __attribute__((weak, alias("Default_Handler")));
-void BusFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
-void UsageFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
 void SVC_Handler(void) __attribute__((weak, alias("Default_Handler")));
 void DebugMon_Handler(void) __attribute__((weak, alias("Default_Handler")));
 void PendSV_Handler(void) __attribute__((weak, alias("Default_Handler")));


### PR DESCRIPTION
The idea is to allow both Brilliant team or 3rd-party developers tinkering on the Monocle to immediately know when they hit a hard fault:

```
Default_Handler    - 0xDEAD0000 (any other unahndled interrupt)
HardFault_Handler  - 0xDEAD0001
BusFault_Handler   - 0xDEAD0002
UsageFault_Handler - 0xDEAD0003
```

This would show-up in the RTT logs, allowing users to tell us, or know for themself, which kind of fault they run into for sure without doing this change by hand themself.

Feel free to dismiss this proposition if not fit.