### PR TITLE
Bring 2 debug tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ SRC_C += modules/device.c
 SRC_C += modules/display.c
 SRC_C += modules/fpga.c
 SRC_C += modules/led.c
+SRC_C += modules/rtt.c
 SRC_C += modules/storage.c
 SRC_C += modules/touch.c
 SRC_C += modules/update.c

--- a/modules/_mountramfs.py
+++ b/modules/_mountramfs.py
@@ -1,0 +1,37 @@
+import os, device
+
+class RAMBlockDev:
+    def __init__(self, block_size, num_blocks):
+        self.block_size = block_size
+        self.data = bytearray(block_size * num_blocks)
+
+    def readblocks(self, block_num, buf, offset=0):
+        addr = block_num * self.block_size + offset
+        for i in range(len(buf)):
+            buf[i] = self.data[addr + i]
+
+    def writeblocks(self, block_num, buf, offset=None):
+        if offset is None:
+            # do erase, then write
+            for i in range(len(buf) // self.block_size):
+                self.ioctl(6, block_num + i)
+            offset = 0
+        addr = block_num * self.block_size + offset
+        for i in range(len(buf)):
+            self.data[addr + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        if op == 4: # block count
+            return len(self.data) // self.block_size
+        if op == 5: # block size
+            return self.block_size
+        if op == 6: # block erase
+            return 0
+
+bdev = RAMBlockDev(512, 32)
+os.VfsLfs2.mkfs(bdev)
+os.mount(bdev, "/")
+
+del os
+del device
+del bdev

--- a/modules/_test.py
+++ b/modules/_test.py
@@ -35,6 +35,8 @@ import update
 import math
 import random
 
+from _rtt import _debug_log
+
 
 def __test(evaluate, expected):
     try:

--- a/modules/rtt.c
+++ b/modules/rtt.c
@@ -29,17 +29,17 @@
 
 #include "nrfx_log.h"
 
-STATIC mp_obj_t rtt_print(mp_obj_t arg1)
+STATIC mp_obj_t rtt_debug_log(mp_obj_t arg1)
 {
     const char *str = mp_obj_str_get_data(arg1, NULL);
 
     NRFX_LOG("%s", str);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(rtt_print_obj, rtt_print);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(rtt_debug_log_obj, rtt_debug_log);
 
 STATIC const mp_rom_map_elem_t rtt_module_globals_table[] = {
-    {MP_ROM_QSTR(MP_QSTR_print), MP_ROM_PTR(&rtt_print_obj)},
+    {MP_ROM_QSTR(MP_QSTR__debug_log), MP_ROM_PTR(&rtt_debug_log_obj)},
 };
 STATIC MP_DEFINE_CONST_DICT(rtt_module_globals, rtt_module_globals_table);
 
@@ -47,4 +47,4 @@ const mp_obj_module_t rtt_module = {
     .base = {&mp_type_module},
     .globals = (mp_obj_dict_t *)&rtt_module_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_rtt, rtt_module);
+MP_REGISTER_MODULE(MP_QSTR__rtt, rtt_module);

--- a/modules/rtt.c
+++ b/modules/rtt.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the MicroPython for Monocle project:
+ *      https://github.com/brilliantlabsAR/monocle-micropython
+ *
+ * Authored by: Josuah Demangeon (me@josuah.net)
+ *              Raj Nakarja / Brilliant Labs Ltd. (raj@itsbrilliant.co)
+ *
+ * ISC Licence
+ *
+ * Copyright © 2023 Brilliant Labs Ltd.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "monocle.h"
+#include "nrf_gpio.h"
+#include "py/runtime.h"
+#include "py/objstr.h"
+
+#include "nrfx_log.h"
+
+STATIC mp_obj_t rtt_print(mp_obj_t arg1)
+{
+    const char *str = mp_obj_str_get_data(arg1, NULL);
+
+    NRFX_LOG("%s", str);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(rtt_print_obj, rtt_print);
+
+STATIC const mp_rom_map_elem_t rtt_module_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR_print), MP_ROM_PTR(&rtt_print_obj)},
+};
+STATIC MP_DEFINE_CONST_DICT(rtt_module_globals, rtt_module_globals_table);
+
+const mp_obj_module_t rtt_module = {
+    .base = {&mp_type_module},
+    .globals = (mp_obj_dict_t *)&rtt_module_globals,
+};
+MP_REGISTER_MODULE(MP_QSTR_rtt, rtt_module);


### PR DESCRIPTION
These debug tools are here for convenience:

- a MicroPython RTT logging module: `import rtt; rtt.print(f'fpga status code: 0x{code:04x}')`
- a RAM filesystem for use in the Nordic DevKit without any flash chip present.

Both are disabled by default, only added manually when in need for debugging.

Feel free to reject this, only here because I had and tested these tools in case that helps...

Related to #221 