### PR TITLE
[WIP] Various bugfixes to get unit tests to work

### DIFF
--- a/main.c
+++ b/main.c
@@ -888,7 +888,7 @@ int main(void)
         mp_stack_set_top(&_stack_top);
 
         // Set the stack limit as smaller than the real stack so we can recover
-        mp_stack_set_limit((char *)&_stack_top - (char *)&_stack_bot - 400);
+        mp_stack_set_limit((char *)&_stack_top - (char *)&_stack_bot - 1024);
 
         // Start garbage collection, micropython and the REPL
         gc_init(&_heap_start, &_heap_end);

--- a/mpconfigport.h
+++ b/mpconfigport.h
@@ -119,6 +119,8 @@
 
 #define MICROPY_EPOCH_IS_1970 (1)
 
+#define MICROPY_STACK_CHECK (1)
+
 #define MP_SSIZE_MAX (0x7fffffff)
 
 #define MP_STATE_PORT MP_STATE_VM


### PR DESCRIPTION
Stack usage limit was set, but stack usage overflow detection was not checked.
Also, the limit of 400 bytes seems a bit small, as there can be relatively large bumps in usage:
Here, 

```
stack_usage=540   +0 
stack_usage=948   +408
stack_usage=948   +0
stack_usage=1332  +384
stack_usage=540   +0
stack_usage=540   +0
stack_usage=540   +0
stack_usage=1156   +616
stack_usage=540    +0
stack_usage=540    +0
[...]
```

So 400 bytes have been exceeded several times.
This turns stack overflow detection, and sets the limit to 1024 as in most other ports.

This is the test case that should be failing (endless recursion apparently), but which ended in a fault before, and in an exception after:

```python
>>> import re
>>> re.match("(a*)*", "aaa")
Traceback (most recent call last):
  File "<stdin>", in <module>
RuntimeError: maximum recursion depth exceeded
>>>
```

From:
https://github.com/micropython/micropython/commit/aba1f9167a7db1c0f19d2ab44a8dbfe5c18cc062
https://github.com/micropython/micropython/commit/8e0b9f495b1967bf7503bfe4e66687955eee1922