### PR TITLE
Reorder the execution of _splashscreen.py and _mountfs.py

### DIFF
--- a/main.c
+++ b/main.c
@@ -909,8 +909,8 @@ int main(void)
         readline_init0();
 
         // Mount the filesystem, or format if needed
-        pyexec_frozen_module("_mountfs.py", false);
         pyexec_frozen_module("_splashscreen.py", false);
+        pyexec_frozen_module("_mountfs.py", false);
 
         // If safe mode is not enabled, run the user's main.py file
         monocle_started_in_safe_mode() ? NRFX_LOG("Starting in safe mode")


### PR DESCRIPTION
If a file on the filesystem is called `display.py`, and this file triggers a bug, such as a hard fault, then `_splashscreen.py` would be importing this dangerous file from the filesystem, and the Monocle would be stuck in a boot loop.

Executing `_splashscreen.py` before the filesystem is mounted avoids breaking the Monocle in case of a name collision with an user-provided file, protecting the boot sequence from bugs elsewhere in the firmware.